### PR TITLE
krb-149: Fjern react-router siden react-router-dom inneholder alt

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,6 @@
     "react-i18next": "^11.18.3",
     "react-nestable": "^2.0.0",
     "react-redux": "^7.2.8",
-    "react-router": "^5.3.3",
     "react-router-dom": "^5.3.3",
     "react-scripts": "5.0.1",
     "redux-thunk": "^2.4.1",

--- a/src/components/ProjectNotFound/ProjectNotFound.tsx
+++ b/src/components/ProjectNotFound/ProjectNotFound.tsx
@@ -3,7 +3,7 @@ import makeStyles from '@mui/styles/makeStyles';
 import React from 'react';
 import { useTranslation } from 'react-i18next';
 import ErrorIcon from '@mui/icons-material/Error';
-import { useHistory } from 'react-router';
+import { useHistory } from 'react-router-dom';
 import theme from '../../theme';
 
 const useStyles = makeStyles({

--- a/src/pages/Home/NewPrefilledResponseForm.tsx
+++ b/src/pages/Home/NewPrefilledResponseForm.tsx
@@ -1,6 +1,6 @@
 import { Box, Typography } from '@mui/material/';
 import { FormProvider, useForm } from 'react-hook-form';
-import { useHistory } from 'react-router';
+import { useHistory } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 
 import GeneralErrorMessage from '../../Form/GeneralErrorMessage';

--- a/src/pages/Home/NewResponseForm.tsx
+++ b/src/pages/Home/NewResponseForm.tsx
@@ -1,6 +1,6 @@
 import { Box, Typography } from '@mui/material/';
 import { FormProvider, useForm } from 'react-hook-form';
-import { useHistory } from 'react-router';
+import { useHistory } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 
 import theme from '../../theme';

--- a/src/pages/Home/NewSpecificationForm.tsx
+++ b/src/pages/Home/NewSpecificationForm.tsx
@@ -1,6 +1,6 @@
 import { Box, Typography } from '@mui/material/';
 import { FormProvider, useForm } from 'react-hook-form';
-import { useHistory } from 'react-router';
+import { useHistory } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 
 import theme from '../../theme';

--- a/src/pages/Home/PrefilledResponseSelectionModal.tsx
+++ b/src/pages/Home/PrefilledResponseSelectionModal.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Box } from '@mui/material';
-import { useHistory } from 'react-router';
+import { useHistory } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 
 import DFODialog from '../../components/DFODialog/DFODialog';

--- a/src/pages/Home/ResponseSelectionModal.tsx
+++ b/src/pages/Home/ResponseSelectionModal.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Box } from '@mui/material';
-import { useHistory } from 'react-router';
+import { useHistory } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 
 import DFODialog from '../../components/DFODialog/DFODialog';

--- a/src/pages/Home/SpecificationSelectionModal.tsx
+++ b/src/pages/Home/SpecificationSelectionModal.tsx
@@ -1,6 +1,6 @@
 import React, { ReactElement, useState } from 'react';
 import { Box, Typography } from '@mui/material';
-import { useHistory } from 'react-router';
+import { useHistory } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 
 import DFODialog from '../../components/DFODialog/DFODialog';

--- a/src/pages/SpecEditor/SpecModule.tsx
+++ b/src/pages/SpecEditor/SpecModule.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Route, Switch } from 'react-router';
+import { Route, Switch } from 'react-router-dom';
 
 import SpecEditor from './SpecEditor';
 import SpecificationGuard from './SpecificationGuard';

--- a/src/pages/Workbench/Admin/AdminGuard.tsx
+++ b/src/pages/Workbench/Admin/AdminGuard.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Route } from 'react-router';
+import { Route } from 'react-router-dom';
 
 import css from './Admin.module.scss';
 import AdminSideBar from './AdminSideBar';

--- a/src/pages/Workbench/Admin/AdminSideBar.tsx
+++ b/src/pages/Workbench/Admin/AdminSideBar.tsx
@@ -7,7 +7,7 @@ import makeStyles from '@mui/styles/makeStyles';
 import React from 'react';
 import SettingsOutlinedIcon from '@mui/icons-material/SettingsOutlined';
 import { Box, List, ListItem, ListItemText } from '@mui/material';
-import { withRouter } from 'react-router';
+import { withRouter } from 'react-router-dom';
 import { Link, useRouteMatch } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 


### PR DESCRIPTION
`react-router` er en basepakke for `react-router-dom` og `react-router-native`.
Alt som trengs finnes i et web-prosjekt finnes i `react-router-dom`.