### PR TITLE
KRB-711 Skru av eslint ved commit for å spare tid ved hver commit

### DIFF
--- a/package.json
+++ b/package.json
@@ -164,7 +164,6 @@
   },
   "pre-commit": [
     "prettier:ci",
-    "lint:ci",
     "test:ci"
   ]
 }


### PR DESCRIPTION
@haroonalam16  og @RaghadAL-Abd Erlend og meg diskuterte dette tidligere i dag. Denne endringen sparer ca 40 sekunder hver commit på min laptop.

Det er fint med commit hooks, men de bør gå veldig raskt, når det tar nærmere ett minutt går det ut over produktiviteten.

Jeg skal prøve å komme tilbake med noe bedre, for linting er nyttig og kan gå mye raskere enn 40 sekunder på et så lite prosjekt.

Linteren vil fortsatt kjøre i Github actions, så feil skal bli oppdaget der.

Og dersom en ønsker å kjøre den selv så kan en kjøre den selv for hånd (`npm run lint:ci`).