### PR TITLE
KRB-729 oppdatere runs-on i ci-development.yaml og release.yml

### DIFF
--- a/.github/workflows/ci-development.yaml
+++ b/.github/workflows/ci-development.yaml
@@ -14,7 +14,7 @@ env:
 
 jobs:
   Build_and_Deploy_to_Azure_Dev:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ env:
 
 jobs:
   Build_and_Release:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2


### PR DESCRIPTION
Oppdatere runs-on i github actions.

Vurderte å sette `runs-on: ubuntu-22.04` men lot være siden det potensielt kan føre til at noe knekker uventet en gang i fremtiden når ubuntu-latest forandres til å peke på en ny release. Dersom det fungerer fint med 22.04 har vi uansett kjøpt oss 4 år.