### PR TITLE
KRB-855 Last opp video og bilder (dersom det feiler) fra cypressjobber

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -7,7 +7,7 @@ on:
       - krb-*
       - KRB-*
   release:
-    types: [ published ]
+    types: [published]
 
 env:
   NODE_VERSION: "16.x"
@@ -166,7 +166,6 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
 
-
   cypress:
     name: Cypress
     runs-on: ubuntu-latest
@@ -205,6 +204,17 @@ jobs:
           REACT_APP_API_URL: ${{ secrets.REACT_APP_API_URL_DEV }}
           REACT_APP_APPLICATION_INSIGHTS_CONNECTION_STRING: ${{ secrets.REACT_APP_APPLICATION_INSIGHTS_CONNECTION_STRING }}
           REACT_APP_APPLICATION_INSIGHTS_ENVIRONMENT: "Cypress E2E-test"
+      - uses: actions/upload-artifact@v3
+        if: failure()
+        with:
+          name: cypress-screenshots
+          path: cypress/screenshots
+        # Test run video was always captured, so this action uses "always()" condition
+      - uses: actions/upload-artifact@v3
+        if: always()
+        with:
+          name: cypress-videos
+          path: cypress/videos
 
   # Deploy
 


### PR DESCRIPTION
(Formateringen i linje 10 og 169 var ikke planlagt, men editoren insisterte.)

Med denne endringen skal det være mulig å se videoer (og bilder, dersom det feiler) fra cypress-testene på GitHub.